### PR TITLE
don't use hash_name but rather hash function directly

### DIFF
--- a/merkletools/__init__.py
+++ b/merkletools/__init__.py
@@ -1,21 +1,10 @@
 import hashlib
 import binascii
-try:
-    import sha3
-except:
-    from warnings import warn
-    warn("sha3 is not working!")
 
 
 class MerkleTools(object):
-    def __init__(self, hash_type="sha256"):
-        hash_type = hash_type.lower()
-        if hash_type in ['sha256', 'md5', 'sha224', 'sha384', 'sha512',
-                         'sha3_256', 'sha3_224', 'sha3_384', 'sha3_512']:
-            self.hash_function = getattr(hashlib, hash_type)
-        else:
-            raise Exception('`hash_type` {} nor supported'.format(hash_type))
-
+    def __init__(self, hash_function=hashlib.sha256):
+        self.hash_function = hash_function
         self.reset_tree()
 
     def _to_hex(self, x):

--- a/tests/test_merkle_tools.py
+++ b/tests/test_merkle_tools.py
@@ -1,4 +1,5 @@
 import hashlib
+import sha3
 from math import sqrt
 from merkletools import MerkleTools
 
@@ -100,7 +101,7 @@ def test_md5_tree():
     bRightmd5 = '92eb5ffee6ae2fec3ad71c777531578f'
     mRootmd5 = hashlib.md5(bytearray.fromhex(bLeftmd5)+bytearray.fromhex(bRightmd5)).hexdigest()
 
-    mt = MerkleTools('md5')
+    mt = MerkleTools(hash_function=hashlib.md5)
     mt.add_leaf([bLeftmd5, bRightmd5])
     mt.make_tree()
     assert mt.get_merkle_root() == mRootmd5
@@ -169,7 +170,7 @@ def test_validate_5_leaves():
 
 # testing other hash functions
 def test_sha224():
-    mt = MerkleTools(hash_type='sha224')
+    mt = MerkleTools(hash_function=hashlib.sha224)
     mt.add_leaf([
         '90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809',
         '35f757ad7f998eb6dd3dd1cd3b5c6de97348b84a951f13de25355177'
@@ -182,7 +183,7 @@ def test_sha224():
 
 
 def test_sha256():
-    mt = MerkleTools(hash_type='sha256')
+    mt = MerkleTools(hash_function=hashlib.sha256)
     mt.add_leaf([
         '1516f000de6cff5c8c63eef081ebcec2ad2fdcf7034db16045d024a90341e07d',
         'e20af19f85f265579ead2578859bf089c92b76a048606983ad83f27ba8f32f1a'
@@ -195,7 +196,7 @@ def test_sha256():
 
 
 def test_sha384():
-    mt = MerkleTools(hash_type='sha384')
+    mt = MerkleTools(hash_function=hashlib.sha384)
     mt.add_leaf([
         '84ae8c6367d64899aef44a951edfa4833378b9e213f916c5eb8492cc37cb951c726e334dace7dbe4bb1dc80c1efe33d0',
         '368c89a00446010def75ad7b179cea9a3d24f8cbb7e2755a28638d194809e7b614eb45453665032860b6c1a135fb6e8b'
@@ -208,7 +209,7 @@ def test_sha384():
 
 
 def test_sha512():
-    mt = MerkleTools(hash_type='sha512')
+    mt = MerkleTools(hash_function=hashlib.sha512)
     mt.add_leaf([
         'c0a8907588c1da716ce31cbef05da1a65986ec23afb75cd42327634dd53d754be6c00a22d6862a42be5f51187a8dff695c530a797f7704e4eb4b473a14ab416e',
         'df1e07eccb2a2d4e1b30d11e646ba13ddc426c1aefbefcff3639405762f216fdcc40a684f3d1855e6d465f99fd9547e53fa8a485f18649fedec5448b45963976'
@@ -221,7 +222,7 @@ def test_sha512():
 
 
 def test_sha3_224():
-    mt = MerkleTools(hash_type='sha3_224')
+    mt = MerkleTools(hash_function=hashlib.sha3_224)
     mt.add_leaf([
         '6ed712b9472b671fd70bb950dc4ccfce197c92a7969f6bc2aa6b6d9f',
         '08db5633d406804d044a3e67683e179b5ee51249ed2139c239d1e65a'
@@ -234,7 +235,7 @@ def test_sha3_224():
 
 
 def test_sha3_224():
-    mt = MerkleTools(hash_type='sha3_224')
+    mt = MerkleTools(hash_function=hashlib.sha3_224)
     mt.add_leaf([
         '6ed712b9472b671fd70bb950dc4ccfce197c92a7969f6bc2aa6b6d9f',
         '08db5633d406804d044a3e67683e179b5ee51249ed2139c239d1e65a'
@@ -247,7 +248,7 @@ def test_sha3_224():
 
 
 def test_sha3_256():
-    mt = MerkleTools(hash_type='sha3_256')
+    mt = MerkleTools(hash_function=hashlib.sha3_256)
     mt.add_leaf([
         '1d7d4ea1cc029ca460e486642830c284657ea0921235c46298b51f0ed1bb7bf7',
         '89b9e14eae37e999b096a6f604adefe7feea4dc240ccecb5e4e92785cffc7070'
@@ -260,7 +261,7 @@ def test_sha3_256():
 
 
 def test_sha3_384():
-    mt = MerkleTools(hash_type='sha3_384')
+    mt = MerkleTools(hash_function=hashlib.sha3_384)
     mt.add_leaf([
         'e222605f939aa69b964a0a03d7075676bb3dbb40c3bd10b22f0adcb149434e7c1085c206f0e3371470a49817aa6d5b16',
         'ae331b6f8643ed7e404471c81be9a74f73fc84ffd5140a0ec9aa8596fa0d0a2ded5f7b780bb2fbfc4e2226ee2a04a2fa'
@@ -273,7 +274,7 @@ def test_sha3_384():
 
 
 def test_sha3_512():
-    mt = MerkleTools(hash_type='sha3_512')
+    mt = MerkleTools(hash_function=hashlib.sha3_512)
     mt.add_leaf([
         '004a237ea808cd9375ee9db9f85625948a890c54e2c30f736f54c969074eb56f0ff3d43dafb4b40d5d974acc1c2a68c046fa4d7c2c20cab6df956514040d0b8b',
         '0b43a85d08c05252d0e23c96bc6b1bda11dfa787049ff452b3c86f4c6135e870c058c05131f199ef8619cfac937a736bbc936a667e4d96a5bf68e4056ce5fdce'


### PR DESCRIPTION
Python idiom is to use duck typing, so let's use it. Also it is possible to use hash functions that your library don't recognize, for example pyblake2.blake2s or pyblake2.blake2b (which use the same API as functions from hashlib)