### PR TITLE
Don't install pysha3 on Python 3.6+

### DIFF
--- a/merkletools/__init__.py
+++ b/merkletools/__init__.py
@@ -1,10 +1,14 @@
 import hashlib
 import binascii
-try:
-    import sha3
-except:
-    from warnings import warn
-    warn("sha3 is not working!")
+import sys
+
+
+if sys.version_info < (3, 6):
+    try:
+        import sha3
+    except:
+        from warnings import warn
+        warn("sha3 is not working!")
 
 
 class MerkleTools(object):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 install_requires = [
-    "pysha3>=1.0b1"
+    "pysha3>=1.0b1; python_version<\"3.6\""
 ]
 
 setup(


### PR DESCRIPTION
`pymerkletools` currently always installs `pysha3`. This makes no sense in Python 3.6+ as SHA3 is already built-in, so it just adds additional unneeded dependency. So I modified `setup.py` to only install and include `pysha3` in Python older than 3.6 which doesn't support SHA3.